### PR TITLE
Add an implementation-defined change threshold exceeded check

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,9 @@
     Each [=global object=] has:
     <ul>
       <li>
+        a <dfn>current pressure state</dfn> (a string), initialized to the empty string.
+      </li>
+      <li>
         a <dfn>pressure observer task queued</dfn> (a boolean), which is initially false.
       </li>
       <li>
@@ -387,7 +390,7 @@
 
 <section> <h2>Contributing Factors</h2>
   <p>
-    <dfn>Contributing factors</dfn> represents the factors contributing to the system performance and current [=pressure state=].
+    <dfn>Contributing factors</dfn> represents the factors contributing to the system performance and [=current pressure state=].
     In case the [=pressure state=] is nominal or fair, the {{PressureRecord}} internal slot {{PressureRecord/[[Factors]]}}
     will always be [=list/empty=].
   </p>
@@ -418,8 +421,8 @@
     <ol>
       <li>
         If [=implementation-defined=] low-level hardware metrics that contribute to the
-        system performance and current [=pressure state=] drop below or exceed an
-        [=implementation-defined=] threshold for the current [=pressure state=], return true.
+        system performance and [=current pressure state=] drop below or exceed an
+        [=implementation-defined=] threshold for the [=current pressure state=], return true.
       </li>
       <li>
         Return false.
@@ -714,7 +717,7 @@ of system resources such as the CPU.
       a <dfn>[[\Source]]</dfn> value of type {{PressureSource}}, which represents the current [=source type=].
     </li>
     <li>
-      a <dfn>[[\State]]</dfn> value of type {{PressureState}}, which represents the current [=pressure state=].
+      a <dfn>[[\State]]</dfn> value of type {{PressureState}}, which represents the [=current pressure state=].
     </li>
     <li>
       a <dfn>[[\Factors]]</dfn>, which is [=ordered set=] of {{PressureFactor}} values,

--- a/index.html
+++ b/index.html
@@ -432,8 +432,8 @@
       The [=change in contributing factors is substantial=] algorithm allows user agents to avoid
       flip-flopping between two states in certain circumstances. For example, a state might otherwise
       change too rapidly in response to a certain system metric that fluctuates around a boundary
-      condition that triggers a state change. This specification does not define
-      the precise algorithm to allow implementations optimize this algorithm to meet their specific needs.
+      condition that triggers a state change. This specification does not define the precise algorithm
+      to allow implementations optimize this algorithm to match the underlying hardware platform's behavior.
       One possible implementation of this algorithm is to use a
       <a href="https://en.wikipedia.org/wiki/Preisach_model_of_hysteresis#Nonideal_relay">nonideal relay</a>
       as a model and identify appropriate lower threshold &#945; and upper threshold &#946; for each

--- a/index.html
+++ b/index.html
@@ -417,7 +417,9 @@
     The <dfn>contributing factors change threshold exceeded</dfn> steps given |factors| and |state|, are as follows:
     <ol>
       <li>
-        If |factors| exceed an [=implementation-defined=] threshold for |state|, return true.
+        If changes in [=contributing factors=] represented by |factors|
+        exceed an [=implementation-defined=] threshold for |state|,
+        return true.
       </li>
       <li>
         Return false.
@@ -425,7 +427,9 @@
     </ol>
     <aside class="note">
       The [=contributing factors change threshold exceeded=] algorithm allows user agents to avoid
-      flip-flopping between two states in certain circumstances. This specification does not define
+      flip-flopping between two states in certain circumstances. For example, a state might otherwise
+      change too rapidly in response to a certain system metric that fluctuates around a boundary
+      condition that triggers a state change. This specification does not define
       the precise algorithm to allow implementations optimize this algorithm to meet their specific needs.
       One possible implementation of this algorithm is to use a
       <a href="https://en.wikipedia.org/wiki/Preisach_model_of_hysteresis#Nonideal_relay">nonideal relay</a>

--- a/index.html
+++ b/index.html
@@ -414,19 +414,19 @@
     </ul>
   </p>
   <p>
-    The <dfn>contributing factors change threshold exceeded</dfn> steps given |factors| and |state|, are as follows:
+    The <dfn>change in contributing factors is substantial</dfn> steps are as follows:
     <ol>
       <li>
-        If changes in [=contributing factors=] represented by |factors|
-        exceed an [=implementation-defined=] threshold for |state|,
-        return true.
+        If [=implementation-defined=] low-level hardware metrics that contribute to the
+        system performance and current [=pressure state=] drop below or exceed an
+        [=implementation-defined=] threshold for the current [=pressure state=], return true.
       </li>
       <li>
         Return false.
       </li>
     </ol>
     <aside class="note">
-      The [=contributing factors change threshold exceeded=] algorithm allows user agents to avoid
+      The [=change in contributing factors is substantial=] algorithm allows user agents to avoid
       flip-flopping between two states in certain circumstances. For example, a state might otherwise
       change too rapidly in response to a certain system metric that fluctuates around a boundary
       condition that triggers a state change. This specification does not define
@@ -940,9 +940,8 @@ of system resources such as the CPU.
           Let |record:PressureRecord| be |observer|.{{PressureObserver/[[LastRecordMap]]}}[|source|].
         </li>
         <li>
-          If |record|.{{PressureRecord/[[State]]}} is not equal to |state| and [=contributing factors change threshold exceeded=]
-          given |factors| and |record|.{{PressureRecord/[[State]]}} returns true,
-          return true.
+          If |record|.{{PressureRecord/[[State]]}} is not equal to |state| and [=change in contributing factors is substantial=]
+          returns true, return true.
         </li>
         <li>
           If |record|.{{PressureRecord/[[Factors]]}} and |factors| are not [=set/supersets=] of each other, return true.

--- a/index.html
+++ b/index.html
@@ -413,6 +413,26 @@
       </li>
     </ul>
   </p>
+  <p>
+    The <dfn>contributing factors change threshold exceeded</dfn> steps given |factors| and |state|, are as follows:
+    <ol>
+      <li>
+        If |factors| exceed an [=implementation-defined=] threshold for |state|, return true.
+      </li>
+      <li>
+        Return false.
+      </li>
+    </ol>
+    <aside class="note">
+      The [=contributing factors change threshold exceeded=] algorithm allows user agents to avoid
+      flip-flopping between two states in certain circumstances. This specification does not define
+      the precise algorithm to allow implementations optimize this algorithm to meet their specific needs.
+      One possible implementation of this algorithm is to use a
+      <a href="https://en.wikipedia.org/wiki/Preisach_model_of_hysteresis#Nonideal_relay">nonideal relay</a>
+      as a model and identify appropriate lower threshold &#945; and upper threshold &#946; for each
+      [=pressure state=] taking special characteristics of each [=contributing factor=] into consideration.
+    </aside>
+  </p>
 </section>
 
 <section> <h2>Pressure Observer</h2>
@@ -916,7 +936,9 @@ of system resources such as the CPU.
           Let |record:PressureRecord| be |observer|.{{PressureObserver/[[LastRecordMap]]}}[|source|].
         </li>
         <li>
-          If |record|.{{PressureRecord/[[State]]}} is not equal to |state|, return true.
+          If |record|.{{PressureRecord/[[State]]}} is not equal to |state| and [=contributing factors change threshold exceeded=]
+          given |factors| and |record|.{{PressureRecord/[[State]]}} returns true,
+          return true.
         </li>
         <li>
           If |record|.{{PressureRecord/[[Factors]]}} and |factors| are not [=set/supersets=] of each other, return true.


### PR DESCRIPTION
- Define "contributing factors change threshold exceeded" steps
- Call into these steps from the "change in data" steps
- Add an informative note for implementation considerations

Fix #176


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/180.html" title="Last updated on Feb 2, 2023, 8:54 AM UTC (0dcdf49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/180/fd09b2e...0dcdf49.html" title="Last updated on Feb 2, 2023, 8:54 AM UTC (0dcdf49)">Diff</a>