### PR TITLE
Fix missing link in security and privacy section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1153,8 +1153,8 @@ of system resources such as the CPU.
     Security and privacy considerations
   </h2>
   <p>
-    Please consult the <a href="security-privacy-self-assessment.md">Security and Privacy Self-Assessment</a>
-    based upon the [[[security-privacy-questionnaire]]].
+    Please consult the <a href="security-privacy-self-assessment.html">Security and Privacy Self-Assessment</a>
+    based upon the [[security-privacy-questionnaire]].
   </p>
   <section>
     <h3>Minimizing information exposure</h3>

--- a/security-privacy-self-assessment.html
+++ b/security-privacy-self-assessment.html
@@ -1,0 +1,86 @@
+<html><head><style>body {
+   color: black;
+}
+</style></head><body><h1 id="security-and-privacy-questionnaire">Security and Privacy Questionnaire</h1>
+<p><a href="https://www.w3.org/TR/security-privacy-questionnaire/">Security and Privacy questionnaire</a>
+responses for the Compute Pressure API</p>
+<h3 id="2-1-what-information-might-this-feature-expose-to-web-sites-or-other-parties-and-for-what-purposes-is-that-exposure-necessary-">2.1. What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?</h3>
+<p>This API exposes a high-level pressure state, consisting of four levels,
+used to indicate whether the system is under pressure and how serious that
+pressure is. This allows websites to react to increases in pressure to
+reduce it before it results in throttling or applications fighting over
+compute resources. Though generally having a nice smooth system is preferred
+from a user point of view, such throttling can be detrimental  to certain
+application types such as e-sports, games and video conferencing.</p>
+<p>In e-sports and games, throttling can result in input lag making you lose the
+game, and in video conferencing systems, throttling can result in connection
+breakage - important words not coming across, or even making it impossible
+to type up minutes while listening to others talk.</p>
+<h2 id="earlier-approach">Earlier approach</h2>
+<p>An earlier revision of this feature exposed CPU utilization and frequency (clock
+ticks) with certain modifications as the values being averaged across cores and
+normalized to a value between 0 and 1 (ignoring certain kinds of boost modes).</p>
+<p>The website could then configure a certain set of thresholds they were interested
+in, but the amount of thresholds would depend on the user agent. This resulted in
+lots of uncertainties and issues. Like some early adopters were uncertain why
+certain thresholds were never crossed due to having created one too
+many thresholds.</p>
+<p>Also, utilization and frequency are not the best metrics available. For instance,
+thermal conditions can easily affect throttling. Utilization might also be
+artificially high because certain processes are stalled on I/O.</p>
+<p>Additionally, CPU design is becoming heterogeneous with different kind of cores
+(e.g. performance core vs efficient core). There are even systems today with more
+than 3 different core types, where all cores are never active at the same time.
+This makes it very hard to look at aggregates and normalized utilization and frequency
+and base programming decisions upon that in a way that they make sense across a
+wide range of current and future devices.</p>
+<p>The new design allows the user agent or underlying system to provide much better
+pressure levels depending on the host system without the user needing to know
+what system the code is running on.</p>
+<h3 id="2-2-is-this-specification-exposing-the-minimum-amount-of-information-necessary-to-power-the-feature-">2.2. Is this specification exposing the minimum amount of information necessary to power the feature?</h3>
+<p>The API design aggressively limits the amount of information exposed.</p>
+<p>The information is exposed as a series of change events, which makes it easy for
+user agents to rate-limit the amount of information revealed over time. The
+specification encourages user agents to rate-limit background windows more
+aggressively than the window the user is interacting with.</p>
+<h3 id="2-3-how-does-this-specification-deal-with-personal-information-or-personally-identifiable-information-or-information-derived-thereof-">2.3. How does this specification deal with personal information or personally-identifiable information or information derived thereof?</h3>
+<p>The information exposed by this API is not personal information or
+personally-identifiable information.</p>
+<h3 id="2-4-how-does-this-specification-deal-with-sensitive-information-">2.4. How does this specification deal with sensitive information?</h3>
+<p>The information exposed by this API is not sensitive information.</p>
+<h3 id="2-5-does-this-specification-introduce-new-state-for-an-origin-that-persists-across-browsing-sessions-">2.5. Does this specification introduce new state for an origin that persists across browsing sessions?</h3>
+<p>This API does not introduce any new persistent state. It exposes device data
+that is likely to change every second.</p>
+<h3 id="2-6-what-information-from-the-underlying-platform-e-g-configuration-data-is-exposed-by-this-specification-to-an-origin-">2.6. What information from the underlying platform, e.g. configuration data, is exposed by this specification to an origin?</h3>
+<p>Aside from the data detailed in question 1, which is data about an instanteneous
+state of the device, no additional data is exposed.</p>
+<h3 id="2-7-does-this-specification-allow-an-origin-access-to-sensors-on-a-user-s-device">2.7. Does this specification allow an origin access to sensors on a userâ€™s device</h3>
+<p>This specification does not allow direct access to sensors. However, the CPU
+clock speed may be used to make broad inferences about the device&#39;s
+temperature.</p>
+<h3 id="2-8-what-data-does-this-specification-expose-to-an-origin-please-also-document-what-data-is-identical-to-data-exposed-by-other-features-in-the-same-or-different-contexts-">2.8. What data does this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.</h3>
+<p>See answer to question 1.</p>
+<p>Some information about CPU utilization can be inferred from the timing of
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame">requestAnimationFrame()</a>&#39;s
+callbacks.</p>
+<h3 id="2-9-does-this-specification-enable-new-script-execution-loading-mechanisms-">2.9. Does this specification enable new script execution/loading mechanisms?</h3>
+<p>No.</p>
+<h3 id="2-10-does-this-specification-allow-an-origin-to-access-other-devices-">2.10. Does this specification allow an origin to access other devices?</h3>
+<p>No.</p>
+<h3 id="2-11-does-this-specification-allow-an-origin-some-measure-of-control-over-a-user-agent-s-native-ui-">2.11. Does this specification allow an origin some measure of control over a user agentâ€™s native UI?</h3>
+<p>No.</p>
+<h3 id="2-12-what-temporary-identifiers-might-this-specification-create-or-expose-to-the-web-">2.12. What temporary identifiers might this specification create or expose to the web?</h3>
+<p>The data obtained in step 1 could pose a cross-origin identification issue,
+however, we think our mitigations would prevent this risk.</p>
+<h3 id="2-13-how-does-this-specification-distinguish-between-behavior-in-first-party-and-third-party-contexts-">2.13. How does this specification distinguish between behavior in first-party and third-party contexts?</h3>
+<p>The specified API will not be available in third-party contexts.</p>
+<h3 id="2-14-how-does-this-specification-work-in-the-context-of-a-user-agent-s-private-browsing-or-incognito-mode-">2.14. How does this specification work in the context of a user agentâ€™s Private Browsing or &quot;incognito&quot; mode?</h3>
+<p>The API works the same way in Private Browsing / &quot;incognito&quot;. We think that the
+cross-origin identification mitigations also prevent identification across
+normal and Private Browsing modes.</p>
+<h3 id="2-15-does-this-specification-have-a-security-considerations-and-privacy-considerations-section-">2.15. Does this specification have a &quot;Security Considerations&quot; and &quot;Privacy Considerations&quot; section?</h3>
+<h3 id="2-16-does-this-specification-allow-downgrading-default-security-characteristics-">2.16. Does this specification allow downgrading default security characteristics?</h3>
+<p>No.</p>
+<h3 id="2-17-what-should-this-questionnaire-have-asked-">2.17. What should this questionnaire have asked?</h3>
+<p>We think that the questions here accurately capture the API&#39;s security and privacy implications.</p>
+</body></html>

--- a/security-privacy-self-assessment.html
+++ b/security-privacy-self-assessment.html
@@ -1,86 +1,221 @@
-<html><head><style>body {
-   color: black;
-}
-</style></head><body><h1 id="security-and-privacy-questionnaire">Security and Privacy Questionnaire</h1>
-<p><a href="https://www.w3.org/TR/security-privacy-questionnaire/">Security and Privacy questionnaire</a>
-responses for the Compute Pressure API</p>
-<h3 id="2-1-what-information-might-this-feature-expose-to-web-sites-or-other-parties-and-for-what-purposes-is-that-exposure-necessary-">2.1. What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?</h3>
-<p>This API exposes a high-level pressure state, consisting of four levels,
-used to indicate whether the system is under pressure and how serious that
-pressure is. This allows websites to react to increases in pressure to
-reduce it before it results in throttling or applications fighting over
-compute resources. Though generally having a nice smooth system is preferred
-from a user point of view, such throttling can be detrimental  to certain
-application types such as e-sports, games and video conferencing.</p>
-<p>In e-sports and games, throttling can result in input lag making you lose the
-game, and in video conferencing systems, throttling can result in connection
-breakage - important words not coming across, or even making it impossible
-to type up minutes while listening to others talk.</p>
-<h2 id="earlier-approach">Earlier approach</h2>
-<p>An earlier revision of this feature exposed CPU utilization and frequency (clock
-ticks) with certain modifications as the values being averaged across cores and
-normalized to a value between 0 and 1 (ignoring certain kinds of boost modes).</p>
-<p>The website could then configure a certain set of thresholds they were interested
-in, but the amount of thresholds would depend on the user agent. This resulted in
-lots of uncertainties and issues. Like some early adopters were uncertain why
-certain thresholds were never crossed due to having created one too
-many thresholds.</p>
-<p>Also, utilization and frequency are not the best metrics available. For instance,
-thermal conditions can easily affect throttling. Utilization might also be
-artificially high because certain processes are stalled on I/O.</p>
-<p>Additionally, CPU design is becoming heterogeneous with different kind of cores
-(e.g. performance core vs efficient core). There are even systems today with more
-than 3 different core types, where all cores are never active at the same time.
-This makes it very hard to look at aggregates and normalized utilization and frequency
-and base programming decisions upon that in a way that they make sense across a
-wide range of current and future devices.</p>
-<p>The new design allows the user agent or underlying system to provide much better
-pressure levels depending on the host system without the user needing to know
-what system the code is running on.</p>
-<h3 id="2-2-is-this-specification-exposing-the-minimum-amount-of-information-necessary-to-power-the-feature-">2.2. Is this specification exposing the minimum amount of information necessary to power the feature?</h3>
-<p>The API design aggressively limits the amount of information exposed.</p>
-<p>The information is exposed as a series of change events, which makes it easy for
-user agents to rate-limit the amount of information revealed over time. The
-specification encourages user agents to rate-limit background windows more
-aggressively than the window the user is interacting with.</p>
-<h3 id="2-3-how-does-this-specification-deal-with-personal-information-or-personally-identifiable-information-or-information-derived-thereof-">2.3. How does this specification deal with personal information or personally-identifiable information or information derived thereof?</h3>
-<p>The information exposed by this API is not personal information or
-personally-identifiable information.</p>
-<h3 id="2-4-how-does-this-specification-deal-with-sensitive-information-">2.4. How does this specification deal with sensitive information?</h3>
-<p>The information exposed by this API is not sensitive information.</p>
-<h3 id="2-5-does-this-specification-introduce-new-state-for-an-origin-that-persists-across-browsing-sessions-">2.5. Does this specification introduce new state for an origin that persists across browsing sessions?</h3>
-<p>This API does not introduce any new persistent state. It exposes device data
-that is likely to change every second.</p>
-<h3 id="2-6-what-information-from-the-underlying-platform-e-g-configuration-data-is-exposed-by-this-specification-to-an-origin-">2.6. What information from the underlying platform, e.g. configuration data, is exposed by this specification to an origin?</h3>
-<p>Aside from the data detailed in question 1, which is data about an instanteneous
-state of the device, no additional data is exposed.</p>
-<h3 id="2-7-does-this-specification-allow-an-origin-access-to-sensors-on-a-user-s-device">2.7. Does this specification allow an origin access to sensors on a userâ€™s device</h3>
-<p>This specification does not allow direct access to sensors. However, the CPU
-clock speed may be used to make broad inferences about the device&#39;s
-temperature.</p>
-<h3 id="2-8-what-data-does-this-specification-expose-to-an-origin-please-also-document-what-data-is-identical-to-data-exposed-by-other-features-in-the-same-or-different-contexts-">2.8. What data does this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.</h3>
-<p>See answer to question 1.</p>
-<p>Some information about CPU utilization can be inferred from the timing of
-<a href="https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame">requestAnimationFrame()</a>&#39;s
-callbacks.</p>
-<h3 id="2-9-does-this-specification-enable-new-script-execution-loading-mechanisms-">2.9. Does this specification enable new script execution/loading mechanisms?</h3>
-<p>No.</p>
-<h3 id="2-10-does-this-specification-allow-an-origin-to-access-other-devices-">2.10. Does this specification allow an origin to access other devices?</h3>
-<p>No.</p>
-<h3 id="2-11-does-this-specification-allow-an-origin-some-measure-of-control-over-a-user-agent-s-native-ui-">2.11. Does this specification allow an origin some measure of control over a user agentâ€™s native UI?</h3>
-<p>No.</p>
-<h3 id="2-12-what-temporary-identifiers-might-this-specification-create-or-expose-to-the-web-">2.12. What temporary identifiers might this specification create or expose to the web?</h3>
-<p>The data obtained in step 1 could pose a cross-origin identification issue,
-however, we think our mitigations would prevent this risk.</p>
-<h3 id="2-13-how-does-this-specification-distinguish-between-behavior-in-first-party-and-third-party-contexts-">2.13. How does this specification distinguish between behavior in first-party and third-party contexts?</h3>
-<p>The specified API will not be available in third-party contexts.</p>
-<h3 id="2-14-how-does-this-specification-work-in-the-context-of-a-user-agent-s-private-browsing-or-incognito-mode-">2.14. How does this specification work in the context of a user agentâ€™s Private Browsing or &quot;incognito&quot; mode?</h3>
-<p>The API works the same way in Private Browsing / &quot;incognito&quot;. We think that the
-cross-origin identification mitigations also prevent identification across
-normal and Private Browsing modes.</p>
-<h3 id="2-15-does-this-specification-have-a-security-considerations-and-privacy-considerations-section-">2.15. Does this specification have a &quot;Security Considerations&quot; and &quot;Privacy Considerations&quot; section?</h3>
-<h3 id="2-16-does-this-specification-allow-downgrading-default-security-characteristics-">2.16. Does this specification allow downgrading default security characteristics?</h3>
-<p>No.</p>
-<h3 id="2-17-what-should-this-questionnaire-have-asked-">2.17. What should this questionnaire have asked?</h3>
-<p>We think that the questions here accurately capture the API&#39;s security and privacy implications.</p>
-</body></html>
+<!DOCTYPE html>
+<html>
+  <head>
+
+    <style>
+    body {
+    color: black;
+    }
+    </style>
+    <title></title>
+  </head>
+  <body>
+    <h1 id="security-and-privacy-questionnaire">
+      Security and Privacy Questionnaire
+    </h1>
+    <p>
+      <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Security
+      and Privacy questionnaire</a> responses for the Compute Pressure API
+    </p>
+    <h3 id=
+    "2-1-what-information-might-this-feature-expose-to-web-sites-or-other-parties-and-for-what-purposes-is-that-exposure-necessary-">
+      2.1. What information might this feature expose to Web sites or other
+      parties, and for what purposes is that exposure necessary?
+    </h3>
+    <p>
+      This API exposes a high-level pressure state, consisting of four levels,
+      used to indicate whether the system is under pressure and how serious
+      that pressure is. This allows websites to react to increases in pressure
+      to reduce it before it results in throttling or applications fighting
+      over compute resources. Though generally having a nice smooth system is
+      preferred from a user point of view, such throttling can be detrimental
+      to certain application types such as e-sports, games and video
+      conferencing.
+    </p>
+    <p>
+      In e-sports and games, throttling can result in input lag making you lose
+      the game, and in video conferencing systems, throttling can result in
+      connection breakage - important words not coming across, or even making
+      it impossible to type up minutes while listening to others talk.
+    </p>
+    <h2 id="earlier-approach">
+      Earlier approach
+    </h2>
+    <p>
+      An earlier revision of this feature exposed CPU utilization and frequency
+      (clock ticks) with certain modifications as the values being averaged
+      across cores and normalized to a value between 0 and 1 (ignoring certain
+      kinds of boost modes).
+    </p>
+    <p>
+      The website could then configure a certain set of thresholds they were
+      interested in, but the amount of thresholds would depend on the user
+      agent. This resulted in lots of uncertainties and issues. Like some early
+      adopters were uncertain why certain thresholds were never crossed due to
+      having created one too many thresholds.
+    </p>
+    <p>
+      Also, utilization and frequency are not the best metrics available. For
+      instance, thermal conditions can easily affect throttling. Utilization
+      might also be artificially high because certain processes are stalled on
+      I/O.
+    </p>
+    <p>
+      Additionally, CPU design is becoming heterogeneous with different kind of
+      cores (e.g. performance core vs efficient core). There are even systems
+      today with more than 3 different core types, where all cores are never
+      active at the same time. This makes it very hard to look at aggregates
+      and normalized utilization and frequency and base programming decisions
+      upon that in a way that they make sense across a wide range of current
+      and future devices.
+    </p>
+    <p>
+      The new design allows the user agent or underlying system to provide much
+      better pressure levels depending on the host system without the user
+      needing to know what system the code is running on.
+    </p>
+    <h3 id=
+    "2-2-is-this-specification-exposing-the-minimum-amount-of-information-necessary-to-power-the-feature-">
+      2.2. Is this specification exposing the minimum amount of information
+      necessary to power the feature?
+    </h3>
+    <p>
+      The API design aggressively limits the amount of information exposed.
+    </p>
+    <p>
+      The information is exposed as a series of change events, which makes it
+      easy for user agents to rate-limit the amount of information revealed
+      over time. The specification encourages user agents to rate-limit
+      background windows more aggressively than the window the user is
+      interacting with.
+    </p>
+    <h3 id=
+    "2-3-how-does-this-specification-deal-with-personal-information-or-personally-identifiable-information-or-information-derived-thereof-">
+      2.3. How does this specification deal with personal information or
+      personally-identifiable information or information derived thereof?
+    </h3>
+    <p>
+      The information exposed by this API is not personal information or
+      personally-identifiable information.
+    </p>
+    <h3 id="2-4-how-does-this-specification-deal-with-sensitive-information-">
+      2.4. How does this specification deal with sensitive information?
+    </h3>
+    <p>
+      The information exposed by this API is not sensitive information.
+    </p>
+    <h3 id=
+    "2-5-does-this-specification-introduce-new-state-for-an-origin-that-persists-across-browsing-sessions-">
+      2.5. Does this specification introduce new state for an origin that
+      persists across browsing sessions?
+    </h3>
+    <p>
+      This API does not introduce any new persistent state. It exposes device
+      data that is likely to change every second.
+    </p>
+    <h3 id=
+    "2-6-what-information-from-the-underlying-platform-e-g-configuration-data-is-exposed-by-this-specification-to-an-origin-">
+      2.6. What information from the underlying platform, e.g. configuration
+      data, is exposed by this specification to an origin?
+    </h3>
+    <p>
+      Aside from the data detailed in question 1, which is data about an
+      instanteneous state of the device, no additional data is exposed.
+    </p>
+    <h3 id=
+    "2-7-does-this-specification-allow-an-origin-access-to-sensors-on-a-user-s-device">
+      2.7. Does this specification allow an origin access to sensors on a
+      userâ€™s device
+    </h3>
+    <p>
+      This specification does not allow direct access to sensors. However, the
+      CPU clock speed may be used to make broad inferences about the device's
+      temperature.
+    </p>
+    <h3 id=
+    "2-8-what-data-does-this-specification-expose-to-an-origin-please-also-document-what-data-is-identical-to-data-exposed-by-other-features-in-the-same-or-different-contexts-">
+      2.8. What data does this specification expose to an origin? Please also
+      document what data is identical to data exposed by other features, in the
+      same or different contexts.
+    </h3>
+    <p>
+      See answer to question 1.
+    </p>
+    <p>
+      Some information about CPU utilization can be inferred from the timing of
+      <a href=
+      "https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame">
+      requestAnimationFrame()</a>'s callbacks.
+    </p>
+    <h3 id=
+    "2-9-does-this-specification-enable-new-script-execution-loading-mechanisms-">
+      2.9. Does this specification enable new script execution/loading
+      mechanisms?
+    </h3>
+    <p>
+      No.
+    </p>
+    <h3 id=
+    "2-10-does-this-specification-allow-an-origin-to-access-other-devices-">
+      2.10. Does this specification allow an origin to access other devices?
+    </h3>
+    <p>
+      No.
+    </p>
+    <h3 id=
+    "2-11-does-this-specification-allow-an-origin-some-measure-of-control-over-a-user-agent-s-native-ui-">
+      2.11. Does this specification allow an origin some measure of control
+      over a user agentâ€™s native UI?
+    </h3>
+    <p>
+      No.
+    </p>
+    <h3 id=
+    "2-12-what-temporary-identifiers-might-this-specification-create-or-expose-to-the-web-">
+      2.12. What temporary identifiers might this specification create or
+      expose to the web?
+    </h3>
+    <p>
+      The data obtained in step 1 could pose a cross-origin identification
+      issue, however, we think our mitigations would prevent this risk.
+    </p>
+    <h3 id=
+    "2-13-how-does-this-specification-distinguish-between-behavior-in-first-party-and-third-party-contexts-">
+      2.13. How does this specification distinguish between behavior in
+      first-party and third-party contexts?
+    </h3>
+    <p>
+      The specified API will not be available in third-party contexts.
+    </p>
+    <h3 id=
+    "2-14-how-does-this-specification-work-in-the-context-of-a-user-agent-s-private-browsing-or-incognito-mode-">
+      2.14. How does this specification work in the context of a user agentâ€™s
+      Private Browsing or "incognito" mode?
+    </h3>
+    <p>
+      The API works the same way in Private Browsing / "incognito". We think
+      that the cross-origin identification mitigations also prevent
+      identification across normal and Private Browsing modes.
+    </p>
+    <h3 id=
+    "2-15-does-this-specification-have-a-security-considerations-and-privacy-considerations-section-">
+      2.15. Does this specification have a "Security Considerations" and
+      "Privacy Considerations" section?
+    </h3>
+    <h3 id=
+    "2-16-does-this-specification-allow-downgrading-default-security-characteristics-">
+      2.16. Does this specification allow downgrading default security
+      characteristics?
+    </h3>
+    <p>
+      No.
+    </p>
+    <h3 id="2-17-what-should-this-questionnaire-have-asked-">
+      2.17. What should this questionnaire have asked?
+    </h3>
+    <p>
+      We think that the questions here accurately capture the API's security
+      and privacy implications.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Fixes: #186


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arskama/compute-pressure/pull/189.html" title="Last updated on Mar 13, 2023, 12:11 PM UTC (89128aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/189/eced55d...arskama:89128aa.html" title="Last updated on Mar 13, 2023, 12:11 PM UTC (89128aa)">Diff</a>