### PR TITLE
Fix typo in "Contributing Factors" section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@
 
 <section> <h2>Contributing Factors</h2>
   <p>
-    Contributing factors represents the underlying hardware metrics contributing to the [=current pressure state=]
+    Contributing factors represent the underlying hardware metrics contributing to the [=current pressure state=]
     and can be [=implementation-defined=].
   </p>
   <p>


### PR DESCRIPTION
Follow-up to #203.
