### PR TITLE
Fix 'declared policy' reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1205,7 +1205,7 @@ of system resources such as the CPU.
         </p>
         <p>
           The feature can be extended to third-party contexts such as iframes only by a
-          <a href="declared policy">declared policy</a>.
+          <a href="https://www.w3.org/TR/permissions-policy/#declared-policy">declared policy</a>.
         </p>
       </section>
     </p>


### PR DESCRIPTION
This should fix the spec-prod error and unblock TR deploy. 

Merging without review as this was supposed to go in #216 as a fix to an obvious copypasta error of mine.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/217.html" title="Last updated on Jun 5, 2023, 10:59 AM UTC (db81eae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/217/823a43b...db81eae.html" title="Last updated on Jun 5, 2023, 10:59 AM UTC (db81eae)">Diff</a>