### PR TITLE
Use same origin checks instead of same origin-domain ones

### DIFF
--- a/index.html
+++ b/index.html
@@ -881,7 +881,7 @@ of system resources such as the CPU.
             they are <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">active needed workers</a>.
           </li>
           <li>
-            Their [=origin=] is [=same origin-domain=] with the [=Node/node document|document=] containing the
+            Their [=origin=] is [=same origin=] with the [=Node/node document|document=] containing the
             <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a> [=node=], or an
             <a href="https://w3c.github.io/picture-in-picture/#initiators-of-active-picture-in-picture-sessions">
             initiator of an active Picture-in-Picture session</a>, or the browsing [=context is capturing=],
@@ -916,7 +916,7 @@ of system resources such as the CPU.
                 initiators of active Picture-in-Picture sessions</a>:
               <ol>
                 <li>
-                  If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin-domain=] with |origin|, return true.
+                  If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin=] with |origin|, return true.
                 </li>
               </ol>
             </li>
@@ -935,7 +935,7 @@ of system resources such as the CPU.
                 currently focused area</a>'s [=Node/node document=].
             </li>
             <li>
-              If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin-domain=] with
+              If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin=] with
               |focusedDocument|'s [=origin=], return true.
             </li>
             <li>


### PR DESCRIPTION
Fixes #187


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arskama/compute-pressure/pull/236.html" title="Last updated on Oct 2, 2023, 5:27 AM UTC (218a80b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/236/2847760...arskama:218a80b.html" title="Last updated on Oct 2, 2023, 5:27 AM UTC (218a80b)">Diff</a>