### PR TITLE
Support workers in privacy algos

### DIFF
--- a/index.html
+++ b/index.html
@@ -889,67 +889,133 @@ of system resources such as the CPU.
           </li>
         </ul>
       </aside>
-      The <dfn>passes privacy test</dfn> steps given the argument |observer:PressureObserver| and
-      its [=relevant global object=] |relevantGlobal|, are as follows:
-      <ol>
-        <li>
-          If |relevantGlobal| is a {{WorkerGlobalScope}} object:
-          <ol>
-            <li>
-              If |relevantGlobal|'s relevant worker is not a <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
-              active needed worker</a>, return false.
-            </li>
-            <li>
-              Otherwise, return true.
-            </li>
-          </ol>
-        </li>
-        <li>
-          If |relevantGlobal| is a {{Window}} object:
-          <ol>
-            <li>
+      <p>
+        To determine the <dfn>owning global object</dfn> for a {{DedicatedWorkerGlobalScope}} |workerGlobalScope|:
+        <ol>
+          <li>
+            If |workerGlobalScope|'s [=WorkerGlobalScope/owner set=] consists of a single {{Document}} |document|,
+            then return |document|'s [=relevant global object=].
+          </li>
+          <li>
+            If |workerGlobalScope|'s [=WorkerGlobalScope/owner set=] consists of a single {{DedicatedWorkerGlobalScope}}
+            |parentWorkerGlobalScope|, then return |parentWorkerGlobalScope|'s [=owning global object=].
+          </li>
+          <li>
+            Return null.
+          </li>
+        </ol>
+        <aside class="note">
+          A {{DedicatedWorkerGlobalScope}}'s [=WorkerGlobalScope/owner set=] will always have exactly one item.
+        </aside>
+      </p>
+      <p>
+        The <dfn>passes window privacy test</dfn> steps given the argument |observer:PressureObserver| and
+        its [=relevant global object=] |relevantGlobal|, are as follows:
+        <ol>
+          <li>
+            Assert: |relevantGlobal| is a {{Window}} object.
+          </li>
+          <li>
             If |relevantGlobal|'s [=associated document=] is not [=Document/fully active=], return false.
-            </li>
-            <li>
-              [=list/For each=] |origin| in
-              <a href="https://w3c.github.io/picture-in-picture/#initiators-of-active-picture-in-picture-sessions">
-                initiators of active Picture-in-Picture sessions</a>:
-              <ol>
-                <li>
-                  If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin=] with |origin|, return true.
-                </li>
-              </ol>
-            </li>
-            <li>
-              If |relevantGlobal|'s [=browsing context=] is [=context is capturing|capturing=], return true.
-            </li>
-            <li>
-              Let |topLevelBC| be |relevantGlobal|'s [=browsing context=]'s [=top-level browsing context=].
-            </li>
-            <li>
-              If |topLevelBC| does not have [=top-level traversable/system focus=], return false.
-            </li>
-            <li>
-              Let |focusedDocument| be the |topLevelBC|'s
-              <a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">
-                currently focused area</a>'s [=Node/node document=].
-            </li>
-            <li>
-              If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin=] with
-              |focusedDocument|'s [=origin=], return true.
-            </li>
-            <li>
-              Otherwise, return false.
-            </li>
-          </ol>
-        </li>
-      </ol>
-      <aside class="note">
-        As there might be multiple observers, each with a different [=requested sampling rate=], the underlying
-        [=platform collector=] will need to use a [=sampling rate=] that fulfills all these requirements. This also
-        means that not every data sample from the [=platform collector=] needs to be delivered to each active
-        observer.
-      </aside>
+          </li>
+          <li>
+            [=list/For each=] |origin| in
+            <a href="https://w3c.github.io/picture-in-picture/#initiators-of-active-picture-in-picture-sessions">
+              initiators of active Picture-in-Picture sessions</a>:
+            <ol>
+              <li>
+                If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin=] with |origin|, return true.
+              </li>
+            </ol>
+          </li>
+          <li>
+            If |relevantGlobal|'s [=browsing context=] is [=context is capturing|capturing=], return true.
+          </li>
+          <li>
+            Let |topLevelBC| be |relevantGlobal|'s [=browsing context=]'s [=top-level browsing context=].
+          </li>
+          <li>
+            If |topLevelBC| does not have [=top-level traversable/system focus=], return false.
+          </li>
+          <li>
+            Let |focusedDocument| be the |topLevelBC|'s
+            <a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">
+              currently focused area</a>'s [=Node/node document=].
+          </li>
+          <li>
+            If |relevantGlobal|'s [=relevant settings object=]'s [=origin=] is [=same origin=] with
+            |focusedDocument|'s [=origin=], return true.
+          </li>
+          <li>
+            Otherwise, return false.
+          </li>
+        </ol>
+      </p>
+      <p>
+        The <dfn>passes privacy test</dfn> steps given the argument |observer:PressureObserver| and
+        its [=relevant global object=] |relevantGlobal|, are as follows:
+        <ol>
+          <li>
+            If |relevantGlobal| is a {{WorkerGlobalScope}} object:
+            <ol>
+              <li>
+                If |relevantGlobal|'s relevant worker is not a <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
+                active needed worker</a>, return false.
+              </li>
+              <li>
+                If |relevantGlobal| is a {{DedicatedWorkerGlobalScope}} object:
+                <ol>
+                  <li>
+                    Let |ownerGlobal| be |relevantGlobal|'s [=owning global object=].
+                  </li>
+                  <li>
+                    Assert: |ownerGlobal| is not null.
+                  </li>
+                  <li>
+                    Return the result of running [=passes window privacy test=] with |observer| and |ownerGlobal|.
+                  </li>
+                </ol>
+              </li>
+              <li>
+                If |relevantGlobal| is a {{SharedWorkerGlobalScope}} object:
+                <ol>
+                  <li>
+                    [=list/For each=] |owner| in |relevantGlobal|'s [=WorkerGlobalScope/owner set=]:
+                    <ol>
+                      <li>
+                        Assert: |owner| is {{Document}}.
+                      </li>
+                      <li>
+                        If the result of running [=passes window privacy test=] with |observer| and |owner|'s
+                        [=relevant global object=] is true, return true, or else [=iteration/continue=].
+                      </li>
+                    </ol>
+                    <li>
+                      Return false.
+                    </li>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>
+            If |relevantGlobal| is not a {{Window}} object, return false.
+          </li>
+          <li>
+            Return the result of running [=passes window privacy test=] with |observer| and |relevantGlobal|.
+          </li>
+        </ol>
+        <aside class="note">
+          {{SharedWorkerGlobalScope}} is only exposed to the {{Window}} object, so shared workers
+          can only be created in this scope, which means that all owners will be {{Document}} objects.
+        </aside>
+        <aside class="note">
+          As there might be multiple observers, each with a different [=requested sampling rate=], the underlying
+          [=platform collector=] will need to use a [=sampling rate=] that fulfills all these requirements. This also
+          means that not every data sample from the [=platform collector=] needs to be delivered to each active
+          observer.
+        </aside>
+      </p>
       The <dfn>passes rate test</dfn> steps given the argument |observer:PressureObserver|,
       |source:PressureSource| and |timestamp:DOMHighResTimeStamp|, are as follows:
       <ol>

--- a/index.html
+++ b/index.html
@@ -959,17 +959,13 @@ of system resources such as the CPU.
             If |relevantGlobal| is a {{WorkerGlobalScope}} object:
             <ol>
               <li>
-                If |relevantGlobal|'s relevant worker is not a <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
-                active needed worker</a>, return false.
-              </li>
-              <li>
                 If |relevantGlobal| is a {{DedicatedWorkerGlobalScope}} object:
                 <ol>
                   <li>
                     Let |ownerGlobal| be |relevantGlobal|'s [=owning global object=].
                   </li>
                   <li>
-                    Assert: |ownerGlobal| is not null.
+                    If |ownerGlobal| is null, return false.
                   </li>
                   <li>
                     Return the result of running [=passes window privacy test=] with |observer| and |ownerGlobal|.
@@ -999,10 +995,15 @@ of system resources such as the CPU.
             </ol>
           </li>
           <li>
-            If |relevantGlobal| is not a {{Window}} object, return false.
+            If |relevantGlobal| is a {{Window}} object:
+            <ol>
+              <li>
+                Return the result of running [=passes window privacy test=] with |observer| and |relevantGlobal|.
+              </li>
+            </ol>
           </li>
           <li>
-            Return the result of running [=passes window privacy test=] with |observer| and |relevantGlobal|.
+            Return false.
           </li>
         </ol>
         <aside class="note">
@@ -1453,6 +1454,11 @@ of system resources such as the CPU.
         <p>
           The feature can be extended to third-party contexts such as iframes only by a
           <a href="https://www.w3.org/TR/permissions-policy/#permissions-policy-declared-policy">declared policy</a>.
+        </p>
+        <p>
+          Shared workers can be shared across documents, such as top level document and those associated iframes. If one
+          of the documents in the [=WorkerGlobalScope/owner set=] passes the above data delivery requirements, the shared worker will
+          qualify for data delivery. This means that the embedded iframe is able to pass along the data to the embedding document.
         </p>
       </section>
     </p>

--- a/index.html
+++ b/index.html
@@ -890,27 +890,30 @@ of system resources such as the CPU.
         </ul>
       </aside>
       <p>
-        To determine the <dfn>owning global object</dfn> for a {{DedicatedWorkerGlobalScope}} |workerGlobalScope|:
+        To determine the <dfn>owning global object set</dfn> for a {{WorkerGlobalScope}} |workerGlobalScope|:
         <ol>
           <li>
-            If |workerGlobalScope|'s [=WorkerGlobalScope/owner set=] consists of a single {{Document}} |document|,
-            then return |document|'s [=relevant global object=].
+            Let |owningGlobalObjectSet| be am empty set.
           </li>
           <li>
-            If |workerGlobalScope|'s [=WorkerGlobalScope/owner set=] consists of a single {{DedicatedWorkerGlobalScope}}
-            |parentWorkerGlobalScope|, then return |parentWorkerGlobalScope|'s [=owning global object=].
-          </li>
-          <li>
-            Return null.
+            [=list/For each=] |owner| in |workerGlobalScope|'s [=WorkerGlobalScope/owner set=]:
+            <ol>
+              <li>
+                If |owner| is a {{Document}}, then [=set/append=] |owner|'s [=relevant global object=] to |owningGlobalObjectSet|.
+              </li>
+              <li>
+                If |owner| is a {{WorkerGlobalScope}}, set |owningGlobalObjectSet| to the [=set/union=] of
+                |owningGlobalObjectSet| and |owner|'s [=owning global object set=].
+              </li>
+            </ol>
+            <li>
+              Return |owningGlobalObjectSet|.
+            </li>
           </li>
         </ol>
-        <aside class="note">
-          A {{DedicatedWorkerGlobalScope}}'s [=WorkerGlobalScope/owner set=] will always have exactly one item.
-        </aside>
       </p>
       <p>
-        The <dfn>passes window privacy test</dfn> steps given the argument |observer:PressureObserver| and
-        its [=relevant global object=] |relevantGlobal|, are as follows:
+        The <dfn>window has implicit focus</dfn> steps given the argument [=relevant global object=] |relevantGlobal|, are as follows:
         <ol>
           <li>
             Assert: |relevantGlobal| is a {{Window}} object.
@@ -952,53 +955,34 @@ of system resources such as the CPU.
         </ol>
       </p>
       <p>
-        The <dfn>passes privacy test</dfn> steps given the argument |observer:PressureObserver| and
-        its [=relevant global object=] |relevantGlobal|, are as follows:
+        The <dfn>may receive data</dfn> steps given the argument |observer:PressureObserver| are as follows:
         <ol>
           <li>
-            If |relevantGlobal| is a {{WorkerGlobalScope}} object:
-            <ol>
-              <li>
-                If |relevantGlobal| is a {{DedicatedWorkerGlobalScope}} object:
-                <ol>
-                  <li>
-                    Let |ownerGlobal| be |relevantGlobal|'s [=owning global object=].
-                  </li>
-                  <li>
-                    If |ownerGlobal| is null, return false.
-                  </li>
-                  <li>
-                    Return the result of running [=passes window privacy test=] with |observer| and |ownerGlobal|.
-                  </li>
-                </ol>
-              </li>
-              <li>
-                If |relevantGlobal| is a {{SharedWorkerGlobalScope}} object:
-                <ol>
-                  <li>
-                    [=list/For each=] |owner| in |relevantGlobal|'s [=WorkerGlobalScope/owner set=]:
-                    <ol>
-                      <li>
-                        Assert: |owner| is {{Document}}.
-                      </li>
-                      <li>
-                        If the result of running [=passes window privacy test=] with |observer| and |owner|'s
-                        [=relevant global object=] is true, return true, or else [=iteration/continue=].
-                      </li>
-                    </ol>
-                    <li>
-                      Return false.
-                    </li>
-                  </li>
-                </ol>
-              </li>
-            </ol>
+            Let |relevantGlobal| be |observer|'s [=relevant global object=].
           </li>
           <li>
             If |relevantGlobal| is a {{Window}} object:
             <ol>
               <li>
-                Return the result of running [=passes window privacy test=] with |observer| and |relevantGlobal|.
+                Return the result of running [=window has implicit focus=] with |relevantGlobal|.
+              </li>
+            </ol>
+          </li>
+          <li>
+            If |relevantGlobal| is a {{WorkerGlobalScope}} object:
+            <ol>
+              <li>Let |owningGlobals| be |relevantGlobal|'s [=owning global object set=].</li>
+              <li>
+                [=list/For each=] |windowGlobal| in |owningGlobals|:
+                <ol>
+                  <li>
+                    If the result of running [=window has implicit focus=] with |windowGlobal| is true,
+                    return true.
+                  </li>
+                  <li>
+                    Otherwise, [=iteration/continue=].
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>
@@ -1006,10 +990,6 @@ of system resources such as the CPU.
             Return false.
           </li>
         </ol>
-        <aside class="note">
-          {{SharedWorkerGlobalScope}} is only exposed to the {{Window}} object, so shared workers
-          can only be created in this scope, which means that all owners will be {{Document}} objects.
-        </aside>
         <aside class="note">
           As there might be multiple observers, each with a different [=requested sampling rate=], the underlying
           [=platform collector=] will need to use a [=sampling rate=] that fulfills all these requirements. This also
@@ -1106,7 +1086,7 @@ of system resources such as the CPU.
           [=registered observer list=] for |source|:
           <ol>
             <li>
-              If running [=passes privacy test=] with |observer|
+              If running [=may receive data=] with |observer|
               returns false, [=iteration/continue=].
             </li>
             <li>
@@ -1276,7 +1256,7 @@ of system resources such as the CPU.
       <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
       active needed workers</a>), like when
       entering the back/forward cache, or "BFCache" for short, then no events are send to the pressure observers
-      (see [=passes privacy test=])
+      (see [=may receive data=])
       in accordance with <a href="https://www.w3.org/TR/design-principles/#listen-fully-active">
       Web Platform Design Principles: Listen for changes to fully active status</a>. This means that the
       system can safely deactivate [=data delivery=] from the associated [=platform collector=],

--- a/index.html
+++ b/index.html
@@ -893,7 +893,7 @@ of system resources such as the CPU.
         To determine the <dfn>owning global object set</dfn> for a {{WorkerGlobalScope}} |workerGlobalScope|:
         <ol>
           <li>
-            Let |owningGlobalObjectSet| be am empty set.
+            Let |owningGlobalObjectSet| be an empty [=set=].
           </li>
           <li>
             [=list/For each=] |owner| in |workerGlobalScope|'s [=WorkerGlobalScope/owner set=]:


### PR DESCRIPTION
- Split up existing algos and add substeps to get owner document for dedicated workers.
- Add steps for dedicated workers and shared workers


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/compute-pressure/pull/238.html" title="Last updated on Oct 16, 2023, 9:29 AM UTC (033bf28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/238/3965ad2...kenchris:033bf28.html" title="Last updated on Oct 16, 2023, 9:29 AM UTC (033bf28)">Diff</a>