### PR TITLE
Provide guidelines for mitigation algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1432,7 +1432,7 @@ of system resources such as the CPU.
       <section>
         <h4>Rate obfuscation normative parameters</h4>
         <p>
-          Base on implementation experience, implementers must use:
+          Based on implementation experience, implementers must use:
           <ul>
             <li>
               a range in between 50 and 100 changes for PressureObserver's {{PressureObserver/[[MaxChangesThreshold]]}} internal slot.

--- a/index.html
+++ b/index.html
@@ -1430,7 +1430,22 @@ of system resources such as the CPU.
         </p>
       </section>
       <section>
-        <h4>Rate obfuscation parameters</h4>
+        <h4>Rate obfuscation normative parameters</h4>
+        <p>
+          Base on implementation experience, implementers must use:
+          <ul>
+            <li>
+              a range in between 50 and 100 changes for PressureObserver's {{PressureObserver/[[MaxChangesThreshold]]}} internal slot.
+            </li>
+            <li>
+              a range in between 5000 milliseconds and 10000 milliseconds for PressureObserver's {{PressureObserver/[[PenaltyDuration]]}} internal slot.
+            </li>
+          </ul>
+          These values are subject to change and are updated based on further implementation experience and research findings.
+        <p>
+      </section>
+      <section>
+      <h4>Rate obfuscation non-normative parameters</h4>
         <p><i>This section is non-normative.</i></p>
         <p>
           Based on implementation experience, implementers are advised to use:
@@ -1438,12 +1453,6 @@ of system resources such as the CPU.
             <li>
               a range in between 300000 milliseconds (5 minutes) and 600000 milliseconds (10 minutes) for PressureObserver's
               {{PressureObserver/[[ObservationWindow]]}} internal slot.
-            </li>
-            <li>
-              a range in between 50 and 100 changes for PressureObserver's {{PressureObserver/[[MaxChangesThreshold]]}} internal slot.
-            </li>
-            <li>
-              a range in between 5000 milliseconds and 10000 milliseconds for PressureObserver's {{PressureObserver/[[PenaltyDuration]]}} internal slot.
             </li>
           </ul>
           These values are subject to change and are updated based on further implementation experience and research findings.

--- a/index.html
+++ b/index.html
@@ -1441,7 +1441,9 @@ of system resources such as the CPU.
               a range in between 5000 milliseconds and 10000 milliseconds for PressureObserver's {{PressureObserver/[[PenaltyDuration]]}} internal slot.
             </li>
           </ul>
-          These values are subject to change and are updated based on further implementation experience and research findings.
+          <aside class="note">
+            These values are subject to change and are updated based on further implementation experience and research findings.
+          </aside>
         <p>
       </section>
       <section>
@@ -1455,7 +1457,9 @@ of system resources such as the CPU.
               {{PressureObserver/[[ObservationWindow]]}} internal slot.
             </li>
           </ul>
-          These values are subject to change and are updated based on further implementation experience and research findings.
+          <aside class="note">
+            These values are subject to change and are updated based on further implementation experience and research findings.
+          </aside>
         </p>
       </section>
       <section>
@@ -1487,9 +1491,9 @@ of system resources such as the CPU.
           Based on implementation experience, implementers are advised to apply the mitigation
           to a randomized time value within a range between 120000 milliseconds (2 minutes) and 240000 milliseconds (4 minutes).
         </p>
-        <p>
+        <aside class="note">
           These values are subject to change and are updated based on further implementation experience and research findings.
-        </p>
+        </aside>
       </section>
       <section>
         <h4>Same-origin restriction</h4>

--- a/index.html
+++ b/index.html
@@ -1436,13 +1436,14 @@ of system resources such as the CPU.
           Based on implementation experience, implementers are advised to use:
           <ul>
             <li>
-              a range in between 300000 milliseconds (5 minutes) and 600000 milliseconds (10 minutes) for |observer|.{{PressureObserver/[[ObservationWindow]]}}.
+              a range in between 300000 milliseconds (5 minutes) and 600000 milliseconds (10 minutes) for PressureObserver's
+              {{PressureObserver/[[ObservationWindow]]}} internal slot.
             </li>
             <li>
-              a range in between 50 and 100 changes for |observer|.{{PressureObserver/[[MaxChangesThreshold]]}}.
+              a range in between 50 and 100 changes for PressureObserver's {{PressureObserver/[[MaxChangesThreshold]]}} internal slot.
             </li>
             <li>
-              a range in between 5000 milliseconds and 10000 milliseconds for |observer|.{{PressureObserver/[[PenaltyDuration]]}}.
+              a range in between 5000 milliseconds and 10000 milliseconds for PressureObserver's {{PressureObserver/[[PenaltyDuration]]}} internal slot.
             </li>
           </ul>
           These values are subject to change and are updated based on further implementation experience and research findings.
@@ -1475,7 +1476,7 @@ of system resources such as the CPU.
         <p><i>This section is non-normative.</i></p>
         <p>
           Based on implementation experience, implementers are advised to apply the mitigation
-          to a randomized time value within a range between 120000 milliseconds (2minutes) and 240000 milliseconds (4 minutes).
+          to a randomized time value within a range between 120000 milliseconds (2 minutes) and 240000 milliseconds (4 minutes).
         </p>
         <p>
           These values are subject to change and are updated based on further implementation experience and research findings.

--- a/index.html
+++ b/index.html
@@ -883,7 +883,7 @@ of system resources such as the CPU.
       <ul>
         <li>
           set |observer|.{{PressureObserver/[[ObservationWindow]]}} to an [=implementation-defined=] randomized integer value in
-          milliseconds within an [=implementation-defined=] range, e.g., random between 300000 and 600000 (5 and 10 minutes).
+          milliseconds within an [=implementation-defined=] range.
         </li>
         <li>
           set |observer|.{{PressureObserver/[[MaxChangesThreshold]]}} to an [=implementation-defined=] randomized integer
@@ -1430,6 +1430,25 @@ of system resources such as the CPU.
         </p>
       </section>
       <section>
+        <h4>Rate obfuscation parameters</h4>
+        <p><i>This section is non-normative.</i></p>
+        <p>
+          Based on implementation experience, implementers are advised to use:
+          <ul>
+            <li>
+              a range in between 300000 milliseconds (5 minutes) and 600000 milliseconds (10 minutes) for |observer|.{{PressureObserver/[[ObservationWindow]]}}.
+            </li>
+            <li>
+              a range in between 50 and 100 changes for |observer|.{{PressureObserver/[[MaxChangesThreshold]]}}.
+            </li>
+            <li>
+              a range in between 5000 milliseconds and 10000 milliseconds for |observer|.{{PressureObserver/[[PenaltyDuration]]}}.
+            </li>
+          </ul>
+          These values are subject to change and are updated based on further implementation experience and research findings.
+        </p>
+      </section>
+      <section>
         <h4>Break calibration</h4>
         <p>
           In a calibration process an attacker tries to manipulate the CPU so that this
@@ -1442,14 +1461,25 @@ of system resources such as the CPU.
           at runtime when this mitigation is running continuously. Any attempts to recalibrate
           will similarly be mitigated against.
         </p>
-        <div class="note">
+        <aside class="note">
           Modern browsers throttle background tabs using [=implementation-defined=]
           heuristics in order to reduce resource usage. For example, after a period of
           no user interaction a background tab can be throttled that will influence
           the global pressure state of the system. This built-in feature of modern
           browsers further improves the effectiveness of the break calibration
           mitigation.
-        </div>
+        </aside>
+      </section>
+      <section>
+        <h4>Break calibration parameters</h4>
+        <p><i>This section is non-normative.</i></p>
+        <p>
+          Based on implementation experience, implementers are advised to apply the mitigation
+          to a randomized time value within a range between 120000 milliseconds (2minutes) and 240000 milliseconds (4 minutes).
+        </p>
+        <p>
+          These values are subject to change and are updated based on further implementation experience and research findings.
+        </p>
       </section>
       <section>
         <h4>Same-origin restriction</h4>


### PR DESCRIPTION
This patch is providing guidelines on numerical values to select for the mitigation algorithms parameters. [1]

[1] https://github.com/w3c/compute-pressure/issues/197#issuecomment-1698413311

Fixes: #240


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arskama/compute-pressure/pull/241.html" title="Last updated on Nov 3, 2023, 11:05 AM UTC (7ca2301)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/241/2873936...arskama:7ca2301.html" title="Last updated on Nov 3, 2023, 11:05 AM UTC (7ca2301)">Diff</a>