### PR TITLE
Use right notation for default allowlist value.

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
   <p>
     The Compute Pressure API defines a [=policy-controlled feature=]
     identified by the token "compute-pressure".
-    Its [=policy-controlled feature/default allowlist=] is `["self"]`.
+    Its [=policy-controlled feature/default allowlist=] is `'self'`.
   </p>
   <p>
     Workers (dedicated and shared) adhere to the permission policy set by their
@@ -307,7 +307,7 @@
   </aside>
   <aside class="note">
     <p>
-      The [=policy-controlled feature/default allowlist=] of `["self"]` allows usage in
+      The [=policy-controlled feature/default allowlist=] of `'self'` allows usage in
       same-origin nested frames but prevents third-party content from using
       the feature.
     </p>


### PR DESCRIPTION
w3c/webappsec-permissions-policy#123 clarified the notation and types used by allowlists and default allowlists.

Default allowlists are not allowlists themselves, so we need to use `"self"` rather than `["self"]`.

Fixes #154


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arskama/compute-pressure/pull/244.html" title="Last updated on Nov 10, 2023, 7:39 AM UTC (a35e8aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/244/2873936...arskama:a35e8aa.html" title="Last updated on Nov 10, 2023, 7:39 AM UTC (a35e8aa)">Diff</a>