### PR TITLE
Rework handling of fully active status

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,8 +1324,8 @@ of system resources such as the CPU.
 
     <ol class="algorithm">
       <li>
-        [=list/For each=] |source| [=map/key=] of the [=registered observer
-        list=] [=ordered map=]:
+        [=list/For each=] |source| [=map/key=] of |relevantGlobal|'s
+        [=registered observer list=] [=ordered map=]:
         <ol>
           <li>
             Deactivate [=data delivery=] of |source| to |relevantGlobal|.

--- a/index.html
+++ b/index.html
@@ -1268,53 +1268,71 @@ of system resources such as the CPU.
     </ol>
   </section>
   <section>
-    <h3>Handling change of fully active</h3>
+    <h3>Handling change of [=Document/fully active=] status</h3>
     <p>
-      When a {{Document}} |document| is no longer [=Document/fully active=],
-      deactivate [=data delivery=] of data of all [=supported source types=] to |document|'s [=relevant global object=].
+      This specification defines the following [=unloading document cleanup
+      steps=] given a {{Document}} |document|:
     </p>
-    <p>
-      When a worker with associated {{WorkerGlobalScope}} |relevantGlobal| is no longer
-      an <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
-      active needed workers</a>,
-      deactivate [=data delivery=] of data of all [=supported source types=] to |relevantGlobal|.
+    <ol class="algorithm">
+      <li>
+        Let |relevantGlobal| be |document:Document|'s [=relevant global
+        object=].
+      </li>
+      <li>
+        [=list/For each=] |source| [=map/key=] of the [=registered observer
+        list=] [=ordered map=]:
+        <ol>
+          <li>
+            Deactivate [=data delivery=] of |source| to |relevantGlobal|.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="issue" data-number="275">
+      This specification previously included steps covering the case of a
+      {{Document}} becoming [=Document/fully active=] again (i.e. integration
+      with {{Document}}'s [=Document/reactivate=] steps). Those steps have been
+      removed while the intended behavior is discussed.
     </p>
-    <p>
-      When a {{Document}} |document| becomes [=Document/fully active=],
-      for each non-[=list/empty=] [=registered observer list=] associated the [=source type=] |source|,
-      activate [=data delivery=] of |source| data to |document|'s [=relevant global object=].
-    </p>
-    <p>
-      When a worker with associated {{WorkerGlobalScope}} |relevantGlobal| becomes
-      an <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
-      active needed workers</a>,
-      for each non-[=list/empty=] [=registered observer list=] associated the [=source type=] |source|,
-      activate [=data delivery=] of |source| data to |document|'s [=relevant global object=].
-    </p>
-    <aside class="note">
-      When a document is no longer [=Document/fully active=] (or associated workers no longer
-      <a href="https://html.spec.whatwg.org/multipage/workers.html#active-needed-worker">
-      active needed workers</a>), like when
-      entering the back/forward cache, or "BFCache" for short, then no events are send to the pressure observers
-      (see [=may receive data=])
-      in accordance with <a href="https://www.w3.org/TR/design-principles/#listen-fully-active">
-      Web Platform Design Principles: Listen for changes to fully active status</a>. This means that the
-      system can safely deactivate [=data delivery=] from the associated [=platform collector=],
-      but also that it needs to be re-activated when the opposite happens.
-    </aside>
   </section>
 
-  <section id="unload-observers">
-    <h3>Handle unloading document and closing of workers</h3>
+  <section>
+    <h3>Handling changes to worker status</h3>
+
+    <aside class="note">
+      <p>
+        This section is similar to the above, but for workers, which do not
+        have an equivalent for the [=unloading document cleanup steps=].
+      </p>
+    </aside>
+
+    <!--
+      Note: the steps below do not properly fit into the the process model for
+      Workers in the HTML spec (i.e. they are not specifically invoked from one
+      or more locations).
+
+      The WebDriver BiDi spec does something similar with different language
+      that can serve as inspiration:
+      https://w3c.github.io/webdriver-bidi/#event-script-realmDestroyed
+    -->
+
     <p>
-      When a worker with associated {{WorkerGlobalScope}} |relevantGlobal|,
-      once |relevantGlobal|'s [=WorkerGlobalScope/closing=] flag is set to true,
-      deactivate [=data delivery=] for all [=supported source types=] to |relevantGlobal|.
+      Whenever a {{WorkerGlobalScope}} |relevantGlobal|'s
+      [=WorkerGlobalScope/closing=] flag is set to true, perform the following
+      steps:
     </p>
-    <p>
-      As one of the [=unloading document cleanup steps=] given {{Document}} |document|,
-      deactivate [=data delivery=] for all [=supported source types=] to |document|'s [=relevant global object=].
-    </p>
+
+    <ol class="algorithm">
+      <li>
+        [=list/For each=] |source| [=map/key=] of the [=registered observer
+        list=] [=ordered map=]:
+        <ol>
+          <li>
+            Deactivate [=data delivery=] of |source| to |relevantGlobal|.
+          </li>
+        </ol>
+      </li>
+    </ol>
   </section>
 </section>
 </section> <!-- Pressure Observer -->


### PR DESCRIPTION
Related to #275, where it is explained that the current model of activating
data delivery again when a document becomes fully active is unclear.

Furthermore, doing the same thing to workers based on whether they are
active needed workers or not does not have precedent in other specs and it
is not clear if the current steps even work or not.

Instead, do the following:
- Remove the steps that handle a document becoming fully active again and
  point to #275.
- Remove the steps that handle a worker becoming an active needed worker
  again for symmetry (and also because it is not clear if it _can_ become an
  active worker again once it it stops being so).
- Merge the "Handle unloading document and closing of workers" section into
  the "Handling change of fully active" one.
  - For documents, the former was basically duplicating the latter. In fact,
    the "unloading document cleanup steps" are how specs are supposed to
    react to a document no longer being fully active.
  - For workers, the "active needed worker" references have been replaced by
    a check for the value of the `closing` flag in WorkerGlobalScope.
- Use proper algorithm steps instead of prose to outline the steps that must
  be performed in both cases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/276.html" title="Last updated on Jun 4, 2024, 8:39 AM UTC (d4a3a26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/276/e6022a2...d4a3a26.html" title="Last updated on Jun 4, 2024, 8:39 AM UTC (d4a3a26)">Diff</a>