### PR TITLE
editorial: fully active checks: Refer to specific registered observer list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1279,8 +1279,8 @@ of system resources such as the CPU.
         object=].
       </li>
       <li>
-        [=list/For each=] |source| [=map/key=] of the [=registered observer
-        list=] [=ordered map=]:
+        [=list/For each=] |source| [=map/key=] of |relevantGlobal|'s
+        [=registered observer list=] [=ordered map=]:
         <ol>
           <li>
             Deactivate [=data delivery=] of |source| to |relevantGlobal|.


### PR DESCRIPTION
Follow-up to #276: use `|relevantGlobal|` in the Document fully active
checks just like we do in the workers section right after it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/277.html" title="Last updated on Jun 4, 2024, 9:56 AM UTC (40e123d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/277/0c7812f...40e123d.html" title="Last updated on Jun 4, 2024, 9:56 AM UTC (40e123d)">Diff</a>