### PR TITLE
editorial: Use more precise algorithmic steps in unobserve() and disconnect()

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,12 +676,20 @@ of system resources such as the CPU.
           Let |relevantGlobal| be [=this=]'s [=relevant global object=].
         </li>
         <li>
-          Remove any [=registered observer=] from |relevantGlobal|'s [=registered observer list=] for
-          |source| for which [=this=] is the [=registered observer=].
+          Let |registeredObserverList| be |relevantGlobal|'s [=registered
+          observer list=] for |source|.
+        <li>
+          [=list/Remove=] any [=registered observer=] from
+          |registeredObserverList| whose [=observer=] is [=this=].
         </li>
         <li>
-          If the above [=registered observer list=] is [=list/empty=],
-          deactivate [=data delivery=] of |source| data to |relevantGlobal|.
+          If |registeredObserverList| is [=list/empty=]:
+          <ol>
+            <li>
+              Deactivate [=data delivery=] of |source| data to
+              |relevantGlobal|.
+            </li>
+          </ol>
         </li>
       </ol>
     </p>
@@ -711,12 +719,24 @@ of system resources such as the CPU.
           Let |relevantGlobal| be [=this=]'s [=relevant global object=].
         </li>
         <li>
-          Remove any [=registered observer=] from |relevantGlobal|'s' [=registered observer list=] for
-          all supported [=source types=] for which [=this=] is the [=observer=].
-        </li>
-        <li>
-          If the above [=registered observer list=] is [=list/empty=],
-          deactivate [=data delivery=] of |source| data to |relevantGlobal|.
+          [=map/For each=] |source| → |registeredObserverList| of
+          |relevantGlobal|'s [=registered observer list=] [=ordered map=]:
+
+          <ol>
+            <li>
+              [=list/Remove=] any [=registered observer=] from
+              |registeredObserverList| whose [=observer=] is [=this=].
+            </li>
+            <li>
+              If |registeredObserverList| is [=list/empty=]:
+              <ol>
+                <li>
+                  Deactivate [=data delivery=] of |source| data to
+                  |relevantGlobal|.
+                </li>
+              </ol>
+            </li>
+          </ol>
         </li>
       </ol>
     </p>

--- a/index.html
+++ b/index.html
@@ -721,7 +721,6 @@ of system resources such as the CPU.
         <li>
           [=map/For each=] |source| → |registeredObserverList| of
           |relevantGlobal|'s [=registered observer list=] [=ordered map=]:
-
           <ol>
             <li>
               [=list/Remove=] any [=registered observer=] from


### PR DESCRIPTION
- Refer to the proper Infra terms for removing items from lists and
  iterating over maps.
- Expand some if-then statements into if + list of steps to prepare for
  upcoming changes that will add more steps to both methods.
- In `unobserve()`, refer to `[=observer=]` rather than `[=registered
  observer=]` when comparing with a PressureObserver (a registered observer
  has an observer, which is a PressureObserver).
- In `disconnect()`, properly define `|source|` before using it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/278.html" title="Last updated on Jun 4, 2024, 10:41 AM UTC (41fac4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/278/0c7812f...41fac4d.html" title="Last updated on Jun 4, 2024, 10:41 AM UTC (41fac4d)">Diff</a>