### PR TITLE
data delivery: Use right time-related variable in passes rate test check

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,7 +1159,7 @@ of system resources such as the CPU.
               returns false, [=iteration/continue=].
             </li>
             <li>
-              If running [=passes rate test=] with |observer|, |source| and |timestamp|
+              If running [=passes rate test=] with |observer|, |source| and |timeValue|
               returns false, [=iteration/continue=].
             </li>
             <li>


### PR DESCRIPTION
Follow-up to #274, related to #257.

The call to the "passes rate test" algorithm should use `timeValue` rather than `timestamp`: the former is what is stored in `PressureRecord.[[Time]]`, so it makes sense to compare values that have been similarly coarsened and converted to a relative time.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/279.html" title="Last updated on Jun 12, 2024, 1:36 PM UTC (67b7e87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/279/1b8a56c...67b7e87.html" title="Last updated on Jun 12, 2024, 1:36 PM UTC (67b7e87)">Diff</a>