### PR TITLE
data delivery: Set `timestamp` as an "unsafe shared current time"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1137,13 +1137,14 @@ of system resources such as the CPU.
         </aside>
         </li>
         <li>
-          Let |timestamp| be a platform-specific timestamp converted in an [=implementation-defined=]
-          way to an [=monotonic clock/unsafe current time=] using the same [=monotonic clock=]
-          that is shared by [=environment settings object/time origins=].
+          Let |timestamp| be [=unsafe shared current time=] corresponding to
+          the moment when |data| was obtained from |relevantGlobal|'s
+          [=platform collector=].
         <aside class="note">
-          The goal of this step is to ensure that a timestamp that may have been relative to
-          a different time origin is converted to a value that can be used in computations with
-          the same [=monotonic clock=] used by the operations described in [[HR-TIME]].
+          The goal of this step is to ensure that the same [=monotonic
+          clock/unsafe current time=] is used across all globals. The value is
+          then converted into a global-specific, [=coarsened moment=] in the
+          step below.
         </aside>
         </li>
         <li>

--- a/index.html
+++ b/index.html
@@ -1137,8 +1137,8 @@ of system resources such as the CPU.
         </aside>
         </li>
         <li>
-          Let |timestamp| be [=unsafe shared current time=] corresponding to
-          the moment when |data| was obtained from |relevantGlobal|'s
+          Let |timestamp| be the [=unsafe shared current time=] corresponding
+          to the moment when |data| was obtained from |relevantGlobal|'s
           [=platform collector=].
         <aside class="note">
           The goal of this step is to ensure that the same [=monotonic


### PR DESCRIPTION
Follow-up to #274, related to #257.

The wording used in #274, which mentions platform-specific timestamps, made more sense in the context of the Generic Sensor API spec, as multiple platform-specific sensor APIs provide samples with timestamps in a platform-specific format that needs to be converted.

Of the OS-provided telemetry APIs, however, only Windows optionally provides samples with a timestamp. As such, it makes more sense to define a timestamp using the monotonic clock's unsafe current time instead. Aditionally, the accompanying note was rewritten to indicate that the same value should be used for all globals, otherwise the same sample would end up with different "raw" timestamps in different frames/workers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/pull/280.html" title="Last updated on Jun 12, 2024, 3:21 PM UTC (8551789)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/280/1b8a56c...8551789.html" title="Last updated on Jun 12, 2024, 3:21 PM UTC (8551789)">Diff</a>