### PR TITLE
Fix #281: Get rid of the global current pressure state

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,9 +408,6 @@
     Each [=global object=] has:
     <ul>
       <li>
-        a <dfn>current pressure state</dfn> (a string), initialized to the empty string.
-      </li>
-      <li>
         a <dfn>pressure observer task queued</dfn> (a boolean), which is initially false.
       </li>
       <li>
@@ -474,7 +471,7 @@
     </li>
     <li>
       a <dfn>[[\ChangesCountMap]]</dfn> [=ordered map=], [=map/keyed=] on a {{PressureSource}},
-      representing the [=source type=] that triggered transition to the [=current pressure state=].
+      representing the [=source type=] that triggered transition to the current [=pressure state=].
       The [=ordered map=]'s [=map/value=] is an integer representing the number of state changes in the
       current observation window timeframe.
     </li>
@@ -523,7 +520,7 @@
 
 <section> <h2>Contributing Factors</h2>
   <p>
-    <dfn>Contributing factors</dfn> represent the underlying hardware metrics contributing to the [=current pressure state=]
+    <dfn>Contributing factors</dfn> represent the underlying hardware metrics contributing to the current [=pressure state=]
     and can be [=implementation-defined=].
   </p>
   <p>
@@ -536,9 +533,9 @@
     <ol>
       <li>
         If [=implementation-defined=] low-level hardware metrics that contribute to the
-        [=current pressure state=] drop below or exceed an, per metric,
+        current [=pressure state=] drop below or exceed an, per metric,
         [=implementation-defined=] threshold
-        for the [=current pressure state=], return true.
+        for the current [=pressure state=], return true.
       </li>
       <li>
         Return false.
@@ -948,7 +945,7 @@ of system resources such as the CPU.
       a <dfn>[[\Source]]</dfn> value of type {{PressureSource}}, which represents the current [=source type=].
     </li>
     <li>
-      a <dfn>[[\State]]</dfn> value of type {{PressureState}}, which represents the [=current pressure state=].
+      a <dfn>[[\State]]</dfn> value of type {{PressureState}}, which represents the current [=pressure state=].
     </li>
     <li>
       a <dfn>[[\Time]]</dfn> value of type {{DOMHighResTimeStamp}},
@@ -1227,8 +1224,7 @@ of system resources such as the CPU.
           Let |record:PressureRecord| be |observer|.{{PressureObserver/[[LastRecordMap]]}}[|source|].
         </li>
         <li>
-          If |record|.{{PressureRecord/[[State]]}} is not equal to |state| and [=change in contributing factors is substantial=]
-          returns true, return true.
+          If |record|.{{PressureRecord/[[State]]}} is not equal to |state|, return true.
         </li>
         <li>
           Return false.
@@ -1408,6 +1404,9 @@ of system resources such as the CPU.
         <li>
           Otherwise:
           <ol>
+            <li>
+              If [=change in contributing factors is substantial=] is false, abort these steps.
+            </li>
             <li>
               Set |state| to an [=adjusted pressure state=] calculated from
               |source| and |sample|'s [=pressure source sample/data=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/compute-pressure/pull/292.html" title="Last updated on Sep 19, 2024, 10:24 AM UTC (2628ae1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/292/2e54dab...kenchris:2628ae1.html" title="Last updated on Sep 19, 2024, 10:24 AM UTC (2628ae1)">Diff</a>