### PR TITLE
Turn issue into note, as workers have their own policy container

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,12 +657,9 @@ of system resources such as the CPU.
               feature=] token "compute-pressure", return [=a promise rejected with=] {{NotAllowedError}}.
             </li>
           </ol>
-          <aside class="issue">
-            <a href="https://github.com/w3c/compute-pressure/issues/110">
-            Permission policy does not support workers directly yet #110</a>, so they cannot be set per
-            individual worker, so for now we consult the policy for all owning documents. For shared
-            workers this means that all owning documents have to have the policy enabled, which should
-            be easy to coordinate as shared workers require same origin.
+          <aside class="note">
+            Workers have their own [=WorkerGlobalScope/policy container=] which can be set via HTTP
+            headers. See the example in [[[#policy-control]]].
           </aside>
         </li>
         </li>


### PR DESCRIPTION
Fixes #243

The inheriting from owners was an issue with shared workers as the owners might not have the same policy. But it has been decided that workers have their own policy container (https://github.com/whatwg/html/pull/6504) which can only be set per HTTP headers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/compute-pressure/pull/303.html" title="Last updated on Nov 22, 2024, 8:24 AM UTC (5735836)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/compute-pressure/303/e879d65...kenchris:5735836.html" title="Last updated on Nov 22, 2024, 8:24 AM UTC (5735836)">Diff</a>